### PR TITLE
Fix generate_schedule tuple usage

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -49,14 +49,13 @@ def generate_schedule_route():
     import time
     try:
         start = time.time()
-        best_schedule = generate_schedule(input_path, int(trimester))
+        best_schedule, fitness_progress = generate_schedule(input_path, int(trimester))
         elapsed = round(time.time() - start, 2)
         excel_out = os.path.join(OUTPUTS_FOLDER, f'timetable_T{trimester}.xlsx')
         json_out = os.path.join(OUTPUTS_FOLDER, f'timetable_T{trimester}.json')
         save_schedule(best_schedule, excel_out, json_out)
         fitness_score = best_schedule.fitness
         conflicts = int(fitness_score // 1000)
-        best_schedule, fitness_progress = generate_schedule(input_path, int(trimester))
         metrics = {
             "fitnessScore": round(10000 / (1 + fitness_score), 2),
             "conflicts": conflicts,

--- a/scripts/run_generate.py
+++ b/scripts/run_generate.py
@@ -12,9 +12,10 @@ def main():
     output_xlsx = f"outputs/timetable_T{trimester}.xlsx"
     output_json = f"outputs/timetable_T{trimester}.json"
 
-    best_schedule = generate_schedule(input_path, trimester)
+    best_schedule, fitness_progress = generate_schedule(input_path, trimester)
     save_schedule(best_schedule, output_xlsx, output_json)
     print(f"Generated: {output_xlsx}, {output_json}")
+    print(f"Fitness progress: {fitness_progress}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- unpack the `(schedule, fitness_progress)` tuple in CLI util
- remove redundant call to `generate_schedule` from Flask route and return progress in response

## Testing
- `python -m py_compile scripts/run_generate.py app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6b7ec97083319f832256cb6e0abb